### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/mclennanApp/src/drvPM304.cc
+++ b/mclennanApp/src/drvPM304.cc
@@ -91,7 +91,7 @@ int PM304_num_cards = 0;
 
 /*----------------functions-----------------*/
 STATIC int recv_mess(int card, char *buff, int len);
-STATIC RTN_STATUS send_mess(int, const char *, char *);
+STATIC RTN_STATUS send_mess(int, const char *, const char *);
 STATIC int send_recv_mess(int card, const char *out, char *in);
 STATIC void start_status(int card);
 STATIC int set_status(int card, int signal);
@@ -333,7 +333,7 @@ STATIC int set_status(int card, int signal)
     {
         strcpy(buff, nodeptr->postmsgptr);
         strcat(buff, "\r");
-        send_mess(card, buff, (char*) NULL);
+        send_mess(card, buff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -354,7 +354,7 @@ STATIC int set_status(int card, int signal)
 /* ring buffer                                       */
 /* send_mess()                                       */
 /*****************************************************/
-STATIC RTN_STATUS send_mess(int card, const char *com, char *name)
+STATIC RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char *p, *tok_save;
     char response[BUFF_SIZE];


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.